### PR TITLE
修复无法获取model，以及环境变量设置顺序问题

### DIFF
--- a/api.py
+++ b/api.py
@@ -3,11 +3,6 @@ import argparse
 from flask import Flask
 from flask_cors import CORS
 
-from modules.login import user_login
-from modules.methods import methods
-from modules.common import set_model
-from modules.model_utils import ModelUtils
-
 parser = argparse.ArgumentParser()
 parser.add_argument("--port", type=int, default="8888")
 parser.add_argument("--model", type=str, default="model/fp16i8-RWKV-4-World-CHNtuned-7B-v1-20230709-ctx4096")
@@ -18,6 +13,11 @@ cmd_opts = parser.parse_args()
 
 os.environ["RWKV_CUDA_ON"] = cmd_opts.cuda_on
 os.environ["RWKV_JIT_ON"] = cmd_opts.jit_on
+
+from modules.login import user_login
+from modules.methods import methods
+from modules.common import set_model
+from modules.model_utils import ModelUtils
 
 set_model(ModelUtils(cmd_opts))
 

--- a/modules/common.py
+++ b/modules/common.py
@@ -3,10 +3,15 @@ from modules.model_utils import ModelUtils
 
 model = None
 
-
 def set_model(model_class: ModelUtils):
     global model
     model = model_class
+    print("set model success")
+
+
+def get_model() -> ModelUtils:
+    global model
+    return model
 
 
 def return_success(data=None, message='success', code=200):


### PR DESCRIPTION
1. 在python 3.11中，通过import导入的global model始终为None，已修改成get_model
2. 由于在通过命令行设置环境变量前就已经引入model_utils，并且model_utils引入了rwkv，在rwkv加载时会根据环境变量动态判断需要添加哪些methods，由于前后环境变量不一致会引起无法获取成员的问题。将引入本体的程序放在设置环境变量之后方可解决。